### PR TITLE
provide privateToPublic method for Keygen

### DIFF
--- a/src/keygen.js
+++ b/src/keygen.js
@@ -4,6 +4,7 @@ const assert = require('assert')
 
 const {PrivateKey} = require('eosjs-ecc')
 const validate = require('./validate')
+const ecc = require('eosjs-ecc')
 
 module.exports = {
   generateMasterKeys,
@@ -172,5 +173,5 @@ function deriveKeys(path, wifsByPath) {
   @return {String} EOSKey
 */
 function privateToPublic(wif) {
-  return PrivateKey.privateToPublic(wif)
+  return ecc.privateToPublic(wif)
 }

--- a/src/keygen.js
+++ b/src/keygen.js
@@ -8,7 +8,8 @@ const validate = require('./validate')
 module.exports = {
   generateMasterKeys,
   authsByPath,
-  deriveKeys
+  deriveKeys,
+  privateToPublic
 }
 
 /**
@@ -163,5 +164,13 @@ function deriveKeys(path, wifsByPath) {
   return newKeys
 }
 
+/**
+  @private privateToPublic
 
+  method of https://github.com/EOSIO/eosjs-ecc#privatetopublic
 
+  @return {String} EOSKey
+*/
+function privateToPublic(wif) {
+  return PrivateKey.privateToPublic(wif)
+}


### PR DESCRIPTION
no need for user to include eosjs-ecc while computing public key by private key.